### PR TITLE
Implement dynamic kanban board

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,250 @@
-#root {
-  max-width: 1280px;
+.app {
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 2.5rem 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
+@media (min-width: 768px) {
+  .app {
+    padding: 3rem 2rem 4rem;
+    gap: 2.5rem;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(2.25rem, 2.8vw + 1.5rem, 3.1rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.page-subtitle {
+  margin: 0;
+  max-width: 42rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.task-form {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 50px -28px rgba(15, 23, 42, 0.45);
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .task-form {
+    grid-template-columns: minmax(0, 260px) minmax(0, 1fr) auto;
+    align-items: end;
+    gap: 1.25rem;
   }
 }
 
-.card {
-  padding: 2em;
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.read-the-docs {
-  color: #888;
+.form-field label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.form-field input,
+.form-field textarea {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(248, 250, 252, 0.9);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.form-field input::placeholder,
+.form-field textarea::placeholder {
+  color: rgba(100, 116, 139, 0.7);
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+}
+
+.form-field textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.task-form button {
+  border: none;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.85rem 1.75rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  width: 100%;
+  min-height: 52px;
+}
+
+@media (min-width: 720px) {
+  .task-form button {
+    width: auto;
+    padding: 0.9rem 2rem;
+  }
+}
+
+.task-form button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -20px rgba(124, 58, 237, 0.75);
+}
+
+.task-form button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.task-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.board {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.column {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 1.25rem;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+  backdrop-filter: blur(6px);
+}
+
+.column--droppable {
+  background-color: rgba(248, 250, 252, 0.96);
+}
+
+.column--active {
+  border-color: #2563eb;
+  box-shadow: 0 18px 38px -28px rgba(37, 99, 235, 0.55);
+  transform: translateY(-2px);
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.column-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(199, 210, 254, 0.9);
+  color: #3730a3;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.column-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1 1 auto;
+}
+
+.empty-state {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  color: #94a3b8;
+  font-size: 0.95rem;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.task-card {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 1rem 1.1rem;
+  box-shadow: 0 18px 36px -26px rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  cursor: grab;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  background-image: linear-gradient(135deg, rgba(79, 70, 229, 0.06), rgba(14, 165, 233, 0));
+}
+
+.task-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px -24px rgba(79, 70, 229, 0.4);
+}
+
+.task-card:active {
+  cursor: grabbing;
+}
+
+.task-card--dragging {
+  opacity: 0.7;
+  transform: scale(0.98);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.task-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.task-description {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+  font-size: 0.95rem;
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,274 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
+const STORAGE_KEY = 'dynamic-kanban.tasks'
+
+const COLUMNS = [
+  { key: 'todo', label: 'To Do' },
+  { key: 'in-progress', label: 'In Progress' },
+  { key: 'done', label: 'Done' },
+]
+
+const createTaskId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `task-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+const getStoredTasks = () => {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+
+    if (!raw) {
+      return []
+    }
+
+    const parsed = JSON.parse(raw)
+
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    const validStatuses = new Set(COLUMNS.map((column) => column.key))
+
+    return parsed
+      .filter((task) => validStatuses.has(task?.status) && typeof task?.id === 'string' && typeof task?.title === 'string')
+      .map((task) => ({
+        id: task.id,
+        title: task.title,
+        description: typeof task.description === 'string' ? task.description : '',
+        status: task.status,
+      }))
+  } catch (error) {
+    console.warn('Unable to read tasks from localStorage:', error)
+    return []
+  }
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [tasks, setTasks] = useState(getStoredTasks)
+  const [formData, setFormData] = useState({ title: '', description: '' })
+  const [activeColumn, setActiveColumn] = useState(null)
+  const [draggedTaskId, setDraggedTaskId] = useState(null)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks))
+    }
+  }, [tasks])
+
+  const tasksByStatus = useMemo(() => {
+    const grouped = Object.fromEntries(COLUMNS.map((column) => [column.key, []]))
+
+    for (const task of tasks) {
+      if (grouped[task.status]) {
+        grouped[task.status].push(task)
+      }
+    }
+
+    return grouped
+  }, [tasks])
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target
+
+    setFormData((current) => ({
+      ...current,
+      [name]: value,
+    }))
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+
+    const title = formData.title.trim()
+    const description = formData.description.trim()
+
+    if (!title) {
+      return
+    }
+
+    const newTask = {
+      id: createTaskId(),
+      title,
+      description,
+      status: 'todo',
+    }
+
+    setTasks((current) => [newTask, ...current])
+
+    setFormData({ title: '', description: '' })
+  }
+
+  const handleDragStart = (event, taskId) => {
+    event.dataTransfer.setData('text/plain', taskId)
+    event.dataTransfer.effectAllowed = 'move'
+    setDraggedTaskId(taskId)
+  }
+
+  const handleDragOver = (event, status) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setActiveColumn((current) => (current === status ? current : status))
+  }
+
+  const handleDrop = (event, status) => {
+    event.preventDefault()
+
+    const taskId = event.dataTransfer.getData('text/plain')
+
+    if (!taskId) {
+      return
+    }
+
+    setTasks((current) => {
+      let hasTask = false
+      let hasStatusChanged = false
+
+      const nextTasks = current.map((task) => {
+        if (task.id !== taskId) {
+          return task
+        }
+
+        hasTask = true
+
+        if (task.status === status) {
+          return task
+        }
+
+        hasStatusChanged = true
+        return {
+          ...task,
+          status,
+        }
+      })
+
+      if (!hasTask || !hasStatusChanged) {
+        return current
+      }
+
+      return nextTasks
+    })
+
+    setActiveColumn(null)
+    setDraggedTaskId(null)
+    event.dataTransfer.clearData()
+  }
+
+  const handleDragLeave = (status) => {
+    setActiveColumn((current) => (current === status ? null : current))
+  }
+
+  const handleDragEnd = () => {
+    setDraggedTaskId(null)
+    setActiveColumn(null)
+  }
+
+  const isSubmitDisabled = !formData.title.trim()
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
+    <div className="app">
+      <header className="page-header">
+        <h1 className="page-title">Dynamic Kanban Board</h1>
+        <p className="page-subtitle">
+          Capture tasks and move them across workflow stages. Drag and drop cards to update their status instantly.
         </p>
+      </header>
+
+      <form className="task-form" onSubmit={handleSubmit}>
+        <div className="form-field">
+          <label htmlFor="task-title">Task title</label>
+          <input
+            id="task-title"
+            name="title"
+            type="text"
+            value={formData.title}
+            onChange={handleInputChange}
+            placeholder="e.g. Prepare sprint review"
+            autoComplete="off"
+            required
+          />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="task-description">Description</label>
+          <textarea
+            id="task-description"
+            name="description"
+            value={formData.description}
+            onChange={handleInputChange}
+            placeholder="Add details, resources, or acceptance criteria..."
+            rows={3}
+          />
+        </div>
+
+        <button type="submit" disabled={isSubmitDisabled}>
+          Add Task
+        </button>
+      </form>
+
+      <div className="board" role="application" aria-label="Kanban board">
+        {COLUMNS.map((column) => {
+          const columnTasks = tasksByStatus[column.key] ?? []
+          const columnTitleId = `${column.key}-title`
+
+          const columnClassNames = ['column']
+
+          if (activeColumn === column.key) {
+            columnClassNames.push('column--active')
+          }
+
+          if (draggedTaskId) {
+            columnClassNames.push('column--droppable')
+          }
+
+          return (
+            <section
+              key={column.key}
+              className={columnClassNames.join(' ')}
+              aria-labelledby={columnTitleId}
+              onDragOver={(event) => handleDragOver(event, column.key)}
+              onDrop={(event) => handleDrop(event, column.key)}
+              onDragLeave={() => handleDragLeave(column.key)}
+            >
+              <header className="column-header">
+                <h2 id={columnTitleId}>{column.label}</h2>
+                <span className="badge" aria-label={`${columnTasks.length} tasks`}>
+                  {columnTasks.length}
+                </span>
+              </header>
+
+              <div className="column-body" role="list">
+                {columnTasks.length === 0 ? (
+                  <p className="empty-state">No tasks here yet. Drop a card to get started.</p>
+                ) : (
+                  columnTasks.map((task) => (
+                    <article
+                      key={task.id}
+                      className={`task-card${draggedTaskId === task.id ? ' task-card--dragging' : ''}`}
+                      draggable
+                      onDragStart={(event) => handleDragStart(event, task.id)}
+                      onDragEnd={handleDragEnd}
+                      role="listitem"
+                      aria-grabbed={draggedTaskId === task.id}
+                    >
+                      <h3 className="task-title">{task.title}</h3>
+                      {task.description ? <p className="task-description">{task.description}</p> : null}
+                    </article>
+                  ))
+                )}
+              </div>
+            </section>
+          )
+        })}
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,43 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  color: #0f172a;
+  background-color: #e2e8f0;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.12) 0%, rgba(99, 102, 241, 0) 55%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.14) 0%, rgba(14, 165, 233, 0) 50%),
+    linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  color: inherit;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin: 0;
 }
 
+input,
+textarea,
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  font: inherit;
 }


### PR DESCRIPTION
## Summary
- replace the starter Vite counter with a three-column kanban board that supports adding tasks and dragging cards between statuses with persistence in localStorage
- restyle the application layout, card design, and form controls to match the kanban workflow experience
- refresh global base styles to support the new UI presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c93be23714832c8e6cd92ab3292f14